### PR TITLE
Add quotes around scalar values in config files, trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ helm install keda kedacore/keda
 Next, prepare the values for the Compute chart:
 
 - `SCCVersion`: The version of Compute you want to deploy
+- `SCCAtmoVersion`: The version of Atmo you want to deploy
 - `EnvToken`: Your Compute environment token (obtained through `subo compute create token <email>`)
 - `BuilderDomain`: The public domain to use for the builder service
 - `StorageClassName`: The name of the storage class for your cloud provider, e.g. "gp2" for AWS or "do-block-storage" for Digital Ocean

--- a/templates/scc-atmo-deployment.yaml
+++ b/templates/scc-atmo-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: atmo
-          image: suborbital/atmo:{{ .Values.SCCAtmoVersion }}
+          image: "suborbital/atmo:{{ .Values.SCCAtmoVersion }}"
           command: ["atmo"]
 
           ports:

--- a/templates/scc-controlplane-deployment.yaml
+++ b/templates/scc-controlplane-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: controlplane
-          image: suborbital/scc-control-plane:{{ .Values.SCCVersion }}
+          image: "suborbital/scc-control-plane:{{ .Values.SCCVersion }}"
           command: ["controlplane"]
 
           ports:
@@ -31,25 +31,25 @@ spec:
           env:
             - name: SCC_HTTP_PORT
               value: "8081"
-            
+
             - name: SCC_LOG_LEVEL
               value: "info"
-            
+
             - name: SCC_HEADLESS
               value: "true"
 
             - name: SCC_ENV_TOKEN
               value: {{ .Values.EnvToken }}
-          
+
           volumeMounts:
             - name: controlplane-storage
               mountPath: "/home/scn"
             - name: controlplane-config
               mountPath: "/home/scn/config"
               readOnly: true
-        
+
         - name: builder
-          image: suborbital/scc-builder:{{ .Values.SCCVersion }}
+          image: "suborbital/scc-builder:{{ .Values.SCCVersion }}"
           command: ["builder"]
 
           ports:
@@ -62,13 +62,13 @@ spec:
 
             - name: SCC_TLS_PORT
               value: "8443"
-            
+
             - name: SCC_LOG_LEVEL
               value: "info"
 
             - name: SCC_CONTROL_PLANE
               value: "scc-controlplane-service:8081"
-          
+
           volumeMounts:
             - mountPath: "/home/scn"
               name: controlplane-storage
@@ -79,7 +79,7 @@ spec:
           volumeMounts:
           - name: controlplane-storage
             mountPath: /data
-      
+
       volumes:
         - name: controlplane-storage
           persistentVolumeClaim:


### PR DESCRIPTION
Does not have an attached issue.

While traversing the repository, goland's helm extension did a bunch of checks on the yaml files, and this PR incorporates suggestions.